### PR TITLE
Improvement/migrate collections

### DIFF
--- a/download_collection_data.py
+++ b/download_collection_data.py
@@ -1,0 +1,80 @@
+"""
+Download all collection data into a file.
+"""
+
+import logging
+import json
+
+LOGGER = None
+
+def configure_logging(log_level=logging.INFO):
+    """
+    Configure logging for this script.
+    :args log_level: logging level to set
+    """
+    global LOGGER
+    logger_name = 'download_collection_data'
+    LOGGER = logging.getLogger(logger_name)
+    LOGGER.setLevel(log_level)
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(log_level)
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s.%(funcName)s, line %(lineno)d - \
+%(levelname)s - %(message)s'
+        )
+    console_handler.setFormatter(formatter)
+    LOGGER.addHandler(console_handler)
+    LOGGER.debug('Starting init of %s', logger_name)
+
+def main():
+    """
+    Called if run from command line.
+    """
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Delete the specified collection replica.'
+        )
+    parser.add_argument(
+        '--url', nargs=1, dest='url', required=True,
+        type=str,
+        help="""The hostname or IP of the SolrCloud cluster, e.g. solrcloud:8983/solr"""
+        )
+    parser.add_argument(
+        '--json_file', nargs=1, dest='json_file', required=True,
+        type=str,
+        help="""The JSON file to write the data to."""
+        )
+    parser.add_argument(
+        '--debug', action='store_true', required=False,
+        help="""Turn on debug logging."""
+        )
+    parser.add_argument(
+        '--local_solrcloudadmin', action='store_true', required=False,
+        help="""Import SolrCloudAdmin from local directory."""
+        )
+    args = parser.parse_args()
+
+    if args.local_solrcloudadmin:
+        import sys
+        sys.path.append('solrcloudadmin')
+        from solrcloudadmin import SolrCloudAdmin
+
+    solr_cloud = None
+    if args.debug:
+        configure_logging(log_level=logging.DEBUG)
+        solr_cloud = SolrCloudAdmin(url=args.url[0], log_level=logging.DEBUG)
+    else:
+        configure_logging(log_level=logging.INFO)
+        solr_cloud = SolrCloudAdmin(url=args.url[0], log_level=logging.INFO)
+
+    json_file = args.json_file[0]
+
+    LOGGER.info('Starting download of data')
+    data = solr_cloud.list_collection_data()
+    LOGGER.info('Writing JSON to file %s', json_file)
+    with open(json_file, 'w') as out_file:
+        json.dump(data, out_file)
+    LOGGER.info('Done')
+
+if __name__ == '__main__':
+    main()

--- a/get_replica_count.py
+++ b/get_replica_count.py
@@ -2,6 +2,7 @@
 Determine how many replicas are assigned to each Solr node.
 """
 
+from __future__ import print_function
 import logging
 import json
 
@@ -11,7 +12,6 @@ def load_json_file(json_file):
     """
     Load the cluster data from a JSON file.
     """
-    import json
     with open(json_file) as data_file:
         data = json.load(data_file)
     return data
@@ -34,7 +34,11 @@ def get_replica_count(collection_data):
     for collection, value in collection_data.items():
         collection_count[collection] = dict()
         for shard, data in value['shards'].items():
-            collection_count[collection][shard] = len(data['replicas'])
+            replica_dict = dict()
+            for replica, core in data['replicas'].items():
+                replica_dict[replica] = core['node_name']
+            collection_count[collection][shard] = replica_dict
+
     return collection_count
 
 def parse_arguments():
@@ -43,7 +47,7 @@ def parse_arguments():
     """
     import argparse
     parser = argparse.ArgumentParser(
-        description='Delete the specified collection replica.'
+        description='Get the summary and list of collection replicas across the cluster'
         )
     parser.add_argument(
         '--url', nargs=1, dest='url', required=False,
@@ -54,6 +58,16 @@ def parse_arguments():
         '--json_file', nargs=1, dest='json_file', required=False,
         type=str,
         help="""The JSON file to read the data from."""
+        )
+    parser.add_argument(
+        '--node_name', nargs=1, dest='node_name', required=False,
+        type=str,
+        help="""Only results that have a replica on this node name will be returned."""
+        )
+    parser.add_argument(
+        '--replica_count', nargs=1, dest='replica_count', required=False,
+        type=int,
+        help="""Only results that have at least replica count will be returned."""
         )
     parser.add_argument(
         '--debug', action='store_true', required=False,
@@ -94,19 +108,35 @@ def main():
         sys.path.append('solrcloudadmin')
         from solrcloudadmin import SolrCloudAdmin
 
-    solr_cloud = None
     if args.debug:
         configure_logging('get_replica_count', log_level=logging.DEBUG)
     else:
         configure_logging('get_replica_count', log_level=logging.INFO)
 
-    if 'url' in vars(args):
-        if args.url:
-            solr_cloud = SolrCloudAdmin(url=args.url[0], log_level=logging.INFO)
+    if 'url' in vars(args) and args.url:
+        solr_cloud = SolrCloudAdmin(url=args.url[0], log_level=logging.INFO)
+    else:
+        solr_cloud = None
 
-    if 'json_file' in vars(args):
-        if args.json_file:
-            json_file = args.json_file[0]
+    if 'json_file' in vars(args) and args.json_file:
+        json_file = args.json_file[0]
+    else:
+        json_file = None
+
+    if 'node_name' in vars(args) and args.node_name:
+        filter_node_name = args.node_name[0]
+    else:
+        filter_node_name = None
+
+    if 'replica_count' in vars(args) and args.replica_count:
+        replica_count = args.replica_count[0]
+    else:
+        replica_count = None
+
+    if not ('url' in vars(args) and args.url) and not\
+        ('json_file' in vars(args) and args.json_file):
+        LOGGER.critical('Need to set either --url or --json_file')
+        return
 
     LOGGER.info('Loading collection states')
     collection_data = get_collection_data(solr_cloud=solr_cloud, json_file=json_file)
@@ -114,9 +144,26 @@ def main():
     LOGGER.info('Starting collection replica count')
     count = get_replica_count(collection_data)
     LOGGER.info('Data format:\nreplica count, collection, shard')
+
     for collection, shards in count.items():
-        for shard, replica_count in shards.items():
-            print '%s,%s,%s' % (replica_count, collection, shard)
+        filter_print = False
+        output_string = ''
+        for shard, replicas in shards.items():
+            if replica_count and len(replicas) < replica_count:
+                continue
+            output_string += 'Summary: replicas=%d, collection=%s, shard=%s\n' % (
+                len(replicas),
+                collection,
+                shard
+                )
+            for core, node_name in replicas.items():
+                output_string += 'core=%s,node_name=%s\n' % (core, node_name)
+                if filter_node_name and node_name == filter_node_name:
+                    filter_print = True
+        if filter_node_name and filter_print:
+            print(output_string, end='')
+        elif not filter_node_name:
+            print(output_string, end='')
 
 if __name__ == '__main__':
     main()

--- a/get_replica_count.py
+++ b/get_replica_count.py
@@ -1,0 +1,122 @@
+"""
+Determine how many replicas are assigned to each Solr node.
+"""
+
+import logging
+import json
+
+LOGGER = None
+
+def load_json_file(json_file):
+    """
+    Load the cluster data from a JSON file.
+    """
+    import json
+    with open(json_file) as data_file:
+        data = json.load(data_file)
+    return data
+
+def get_collection_data(solr_cloud=None, json_file=None):
+    """
+    Load the collection data either from a file
+    or from the SolrCloud cluster.
+    """
+    if json_file:
+        return load_json_file(json_file=json_file)
+    elif solr_cloud:
+        return solr_cloud.list_collection_data()
+
+def get_replica_count(collection_data):
+    """
+    Get the count of replicas each collection has.
+    """
+    collection_count = dict()
+    for collection, value in collection_data.items():
+        collection_count[collection] = dict()
+        for shard, data in value['shards'].items():
+            collection_count[collection][shard] = len(data['replicas'])
+    return collection_count
+
+def parse_arguments():
+    """
+    Parse command line arguments.
+    """
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Delete the specified collection replica.'
+        )
+    parser.add_argument(
+        '--url', nargs=1, dest='url', required=False,
+        type=str,
+        help="""The hostname or IP of the SolrCloud cluster, e.g. solrcloud:8983/solr"""
+        )
+    parser.add_argument(
+        '--json_file', nargs=1, dest='json_file', required=False,
+        type=str,
+        help="""The JSON file to read the data from."""
+        )
+    parser.add_argument(
+        '--debug', action='store_true', required=False,
+        help="""Turn on debug logging."""
+        )
+    parser.add_argument(
+        '--local_solrcloudadmin', action='store_true', required=False,
+        help="""Import SolrCloudAdmin from local directory."""
+        )
+    return parser.parse_args()
+
+def configure_logging(logger_name, log_level=logging.INFO):
+    """
+    Configure logging for this script.
+    :args log_level: logging level to set
+    """
+    global LOGGER
+    LOGGER = logging.getLogger(logger_name)
+    LOGGER.setLevel(log_level)
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(log_level)
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s.%(funcName)s, line %(lineno)d - \
+%(levelname)s - %(message)s'
+        )
+    console_handler.setFormatter(formatter)
+    LOGGER.addHandler(console_handler)
+    LOGGER.debug('Starting init of %s', logger_name)
+
+def main():
+    """
+    Called if run from command line.
+    """
+    args = parse_arguments()
+
+    if args.local_solrcloudadmin:
+        import sys
+        sys.path.append('solrcloudadmin')
+        from solrcloudadmin import SolrCloudAdmin
+
+    solr_cloud = None
+    if args.debug:
+        configure_logging('get_replica_count', log_level=logging.DEBUG)
+    else:
+        configure_logging('get_replica_count', log_level=logging.INFO)
+
+    if 'url' in vars(args):
+        if args.url:
+            solr_cloud = SolrCloudAdmin(url=args.url[0], log_level=logging.INFO)
+
+    if 'json_file' in vars(args):
+        if args.json_file:
+            json_file = args.json_file[0]
+
+    LOGGER.info('Loading collection states')
+    collection_data = get_collection_data(solr_cloud=solr_cloud, json_file=json_file)
+
+    LOGGER.info('Starting collection replica count')
+    count = get_replica_count(collection_data)
+    LOGGER.info('Data format:\nreplica count, collection, shard')
+    for collection, shards in count.items():
+        for shard, replica_count in shards.items():
+            print '%s,%s,%s' % (replica_count, collection, shard)
+
+if __name__ == '__main__':
+    main()

--- a/migrate_collections.py
+++ b/migrate_collections.py
@@ -35,9 +35,9 @@ def check_node_live(solr_cloud, collection, shard, node_to_check):
         return False
     shard_data = solr_cloud.get_collection_state(collection=collection)['shards'][shard]
     for replica, core in shard_data['replicas'].items():
-        LOGGER.debug('replica = %s', replica)
-        LOGGER.debug('node_name = %s', core['node_name'])
-        LOGGER.debug('node_to_check = %s', node_to_check)
+        LOGGER.debug('replica=%s', replica)
+        LOGGER.debug('node_name=%s', core['node_name'])
+        LOGGER.debug('node_to_check=%s', node_to_check)
         if node_to_check == core['node_name']:
             return True
     return False
@@ -50,9 +50,9 @@ def check_node_snapshot(shard_data, node_to_check):
     if not node_to_check:
         return False
     for replica, core in shard_data['replicas'].items():
-        LOGGER.debug('replica = %s', replica)
-        LOGGER.debug('node_name = %s', core['node_name'])
-        LOGGER.debug('node_to_check = %s', node_to_check)
+        LOGGER.debug('replica=%s', replica)
+        LOGGER.debug('node_name=%s', core['node_name'])
+        LOGGER.debug('node_to_check=%s', node_to_check)
         if node_to_check == core['node_name']:
             return True
     return False
@@ -90,14 +90,14 @@ def add_replicas(
     """
     if dryrun:
         LOGGER.warn('This is a dry run!')
-    LOGGER.debug('dryrun = %s', dryrun)
+    LOGGER.debug('dryrun=%s', dryrun)
 
     # Reset request ID
     response = solr_cloud.get_request_status('-1')
-    LOGGER.debug('response = %s', response)
+    LOGGER.debug('response=%s', response)
     if response['responseHeader']['status'] != 0:
         LOGGER.critical(
-            'Cleaning up stored states failed:\nresponse = %s',
+            'Cleaning up stored states failed, response=%s',
             response
             )
         return False
@@ -108,21 +108,21 @@ def add_replicas(
     count = 0
     for collection, value in collection_list.items():
         LOGGER.debug('loop count=%d', count)
-        LOGGER.debug('collection: %s', collection)
+        LOGGER.debug('collection=%s', collection)
         LOGGER.debug(
-            'collection dict = %s',
+            'collection dict=%s',
             value
             )
         for shard, data in value['shards'].items():
-            LOGGER.debug('shard = %s', shard)
-            LOGGER.debug('data = %s', data)
+            LOGGER.debug('shard=%s', shard)
+            LOGGER.debug('data=%s', data)
             # Check if source node has a copy of the collection, shard
             if not check_node_snapshot(shard_data=data, node_to_check=source_node):
-                LOGGER.debug('No replica on source_node for shard %s', shard)
+                LOGGER.debug('No replica on source_node for shard=%s', shard)
                 continue
             if check_node_snapshot(shard_data=data, node_to_check=source_node):
                 LOGGER.warn(
-                    'Snapshot of state.json lists a replica on the destination_node %s',
+                    'Snapshot of state.json lists a replica on the destination_node=%s',
                     destination_node
                     )
                 continue
@@ -133,12 +133,12 @@ def add_replicas(
                     node_to_check=source_node
                 ):
                 LOGGER.warn(
-                    'Live state.json check lists a replica on the destination_node %s',
+                    'Live state.json check lists a replica on the destination_node=%s',
                     destination_node
                     )
 
             LOGGER.info(
-                'Adding replica for collection %s, shard %s',
+                'Adding replica for collection=%s, shard=%s',
                 collection,
                 shard
                 )
@@ -153,11 +153,11 @@ def add_replicas(
                 node=destination_node,
                 async=request_id
                 )
-            LOGGER.debug('response = %s', response)
+            LOGGER.debug('response=%s', response)
             if response['responseHeader']['status'] != 0 or 'error' in response:
                 LOGGER.error(
-                    'Unable to add replica for collection %s, \
-shard %s. response = %s',
+                    'Unable to add replica for collection=%s, \
+shard=%s. response=%s',
                     collection,
                     shard,
                     response
@@ -165,7 +165,7 @@ shard %s. response = %s',
                 continue
             if wait_for_async(solr_cloud, request_id):
                 LOGGER.info(
-                    'Successfully added replica for collection %s, shard %s',
+                    'Successfully added replica for collection=%s, shard=%s',
                     collection,
                     shard
                     )
@@ -269,7 +269,7 @@ collection=%s, shard=%s on the source_node=%s',
                 shard=shard,
                 replica=replica
                 )
-            LOGGER.debug('response = %s', response)
+            LOGGER.debug('response=%s', response)
             if response['responseHeader']['status'] != 0 or 'error' in response:
                 LOGGER.error(
                     'Unable to delete replica=%s for collection=%s, \

--- a/migrate_collections.py
+++ b/migrate_collections.py
@@ -202,6 +202,7 @@ def delete_replicas(
             'collection dict=%s',
             value
             )
+        replication_factor = int(value['replicationFactor'])
         for shard, data in value['shards'].items():
             LOGGER.debug('shard=%s', shard)
             LOGGER.debug('data=%s', data)
@@ -227,16 +228,31 @@ collection=%s, shard=%s on the source_node=%s',
                     )
                 continue
 
-            # Check if replica count is greater then 1
+            # Check if replica count os greater then 1 and above replication_factor
             LOGGER.debug(
                 'Replica count for collection=%s, shard=%s is %d',
                 collection,
                 shard,
                 len(data['replicas'])
                 )
-            if len(data['replicas']) < 2:
+            if len(data['replicas']) <= 1:
                 LOGGER.error(
-                    'Will not delete final replica of shard, count less then 2'
+                    'Will not delete final replica of collection=%s, shard=%s, \
+replica count is %d <= 1',
+                    collection,
+                    shard,
+                    len(data['replicas'])
+                )
+                continue
+            elif len(data['replicas']) <= replication_factor:
+                LOGGER.error(
+                    'Will not delete replica of collection=%s, shard=%s, \
+when replica count below or equal to replication factor, \
+count of replicas=%d <= replication_factor=%d',
+                    collection,
+                    shard,
+                    len(data['replicas']),
+                    replication_factor
                 )
                 continue
 

--- a/migrate_collections.py
+++ b/migrate_collections.py
@@ -3,60 +3,181 @@ Migrate collections from one host to another.
 """
 
 import logging
+import time
 
 LOGGER = None
 
-def find_collection(solr_cloud, source_node, destination_node=None):
+def load_json_file(json_file):
     """
-    Find a collection that needs to be moved.
+    Load the cluster data from a JSON file.
     """
-    for collection in solr_cloud.list_collections_only():
-        data = solr_cloud.get_collection_state(collection=collection)
-        for shard in data['shards']:
-            for replica in data['shards'][shard]['replicas']:
-                if data['shards'][shard]['replicas'][replica]['node_name'] == source_node:
-                    # Check destination for a copy of the shard
-                    if destination_node:
-                        response = check_destination(
-                            solr_cloud=solr_cloud,
-                            collection=collection,
-                            shard=shard,
-                            destination_node=destination_node
-                            )
-                        if response['status'] != 0:
-                            LOGGER.warn(
-                                'Problem with destination for replica.\n\
-                                Response:\n\
-                                %s\n\
-                                Collection, shard, and replica information:\n\
-                                %s',
-                                solr_cloud.pretty_format(response),
-                                solr_cloud.pretty_format(data)
-                                )
-                            continue
+    import json
+    with open(json_file) as data_file:
+        data = json.load(data_file)
+    return data
 
-                    return_dict = {
-                        'collection': collection,
-                        'shard': shard,
-                        'replica': replica
-                        }
-                    LOGGER.debug('Found match: %s', solr_cloud.pretty_format(return_dict))
-                    return return_dict
+def get_collection_data(solr_cloud=None, json_file=None):
+    """
+    Load the collection data either from a file
+    or from the SolrCloud cluster.
+    """
+    if json_file:
+        return load_json_file(json_file=json_file)
+    elif solr_cloud:
+        return solr_cloud.list_collection_data()
 
-def check_destination(solr_cloud, collection, shard, destination_node):
+def check_node_live(solr_cloud, collection, shard, node_to_check):
     """
-    Verify that the destination node does not already have the collection.
+    Pulls the current collection state.json and checks if the destination_node
+    node already has a copy of the shard.
     """
-    data = solr_cloud.get_collection_state(collection)
-    for replica in data['shards'][shard]['replicas']:
-        if data['shards'][shard]['replicas'][replica]['node_name'] == destination_node:
-            return {
-                'status': 1,
-                'message': 'Replica already on destination node.'
-                }
-    return {
-        'status': 0
-        }
+    if not node_to_check:
+        return False
+    shard_data = solr_cloud.get_collection_state(collection=collection)['shards'][shard]
+    for replica, core in shard_data['replicas'].items():
+        LOGGER.debug('replica = %s', replica)
+        LOGGER.debug('node_name = %s', core['node_name'])
+        LOGGER.debug('node_to_check = %s', node_to_check)
+        if node_to_check == core['node_name']:
+            return True
+    return False
+
+def check_node_snapshot(shard_data, node_to_check):
+    """
+    Uses the snapshot of the SolrCloud cluster state.json files and checks if
+    the destination_node node already has a copy of the shard.
+    """
+    if not node_to_check:
+        return False
+    for replica, core in shard_data['replicas'].items():
+        LOGGER.debug('replica = %s', replica)
+        LOGGER.debug('node_name = %s', core['node_name'])
+        LOGGER.debug('node_to_check = %s', node_to_check)
+        if node_to_check == core['node_name']:
+            return True
+    return False
+
+
+def wait_for_async(solr_cloud, async):
+    """
+    Wait for an async job to finish.
+    """
+    while True:
+        response = solr_cloud.get_request_status(async)
+        LOGGER.debug('response = %s', response)
+        if response['status']['state'] == 'running':
+            LOGGER.debug('Waiting for job to finish...')
+            time.sleep(2)
+            continue
+        elif response['status']['state'] == 'completed':
+            return True
+        else:
+            LOGGER.critical('Unexpected task state\nresponse = %s', response)
+            return False
+
+def add_replicas(
+        solr_cloud,
+        collection_list,
+        source_node,
+        destination_node=None,
+        limit=0,
+        dryrun=False
+    ):
+    """
+    Add replicas for collections on source node.
+
+    If destination_node is specified then collections will be added to it.
+    """
+    if dryrun:
+        LOGGER.warn('This is a dry run!')
+    LOGGER.debug('dryrun = %s', dryrun)
+
+    # Reset request ID
+    response = solr_cloud.get_request_status('-1')
+    LOGGER.debug('response = %s', response)
+    if response['responseHeader']['status'] != 0:
+        LOGGER.critical(
+            'Cleaning up stored states failed:\nresponse = %s',
+            response
+            )
+        return False
+
+    # Set starting point for request IDs
+    request_id = 1000
+
+    count = 0
+    for collection, value in collection_list.items():
+        LOGGER.debug('collection: %s', collection)
+        LOGGER.debug(
+            'collection dict = %s',
+            value
+            )
+        for shard, data in value['shards'].items():
+            LOGGER.debug('shard = %s', shard)
+            LOGGER.debug('data = %s', data)
+            # Check if source node has a copy of the collection, shard
+            if not check_node_snapshot(shard_data=data, node_to_check=source_node):
+                LOGGER.debug('No replica on source_node for shard %s', shard)
+                continue
+            if check_node_snapshot(shard_data=data, node_to_check=source_node):
+                LOGGER.warn(
+                    'Snapshot of state.json lists a replica on the destination_node %s',
+                    destination_node
+                    )
+                continue
+            if check_node_live(
+                    solr_cloud=solr_cloud,
+                    collection=collection,
+                    shard=shard,
+                    node_to_check=source_node
+                ):
+                LOGGER.warn(
+                    'Live state.json check lists a replica on the destination_node %s',
+                    destination_node
+                    )
+
+            LOGGER.info(
+                'Adding replica for collection %s, shard %s',
+                collection,
+                shard
+                )
+            count += 1
+
+            if dryrun:
+                continue
+
+            response = solr_cloud.add_replica(
+                collection=collection,
+                shard=shard,
+                node=destination_node,
+                async=request_id
+                )
+            LOGGER.debug('response = %s', response)
+            if response['responseHeader']['status'] != 0 or 'error' in response:
+                LOGGER.error(
+                    'Unable to add replica for collection %s, \
+shard %s. response = %s',
+                    collection,
+                    shard,
+                    response
+                    )
+                continue
+            if wait_for_async(solr_cloud, request_id):
+                LOGGER.info(
+                    'Successfully added replica for collection %s, shard %s',
+                    collection,
+                    shard
+                    )
+                request_id += 1
+            else:
+                LOGGER.critical(
+                    'Unable to add replica, check response from wait_for_async.'
+                    )
+                return False
+
+        if limit > 0 and count >= limit:
+            break
+    return True
 
 def parse_arguments():
     """
@@ -72,19 +193,31 @@ def parse_arguments():
         help="""The hostname or IP of the SolrCloud cluster, e.g. solrcloud:8983/solr"""
         )
     parser.add_argument(
-        '-s', nargs=1, dest='source_node', required=True,
+        '--source_node', nargs=1, dest='source_node', required=True,
         type=str,
         help="""The source host as SolrCloud formated node_name."""
         )
     parser.add_argument(
-        '-d', nargs=1, dest='destination_node', required=False,
+        '--destination_node', nargs=1, dest='destination_node', required=False,
         type=str,
         help="""The destination host as SolrCloud formated node_name."""
         )
     parser.add_argument(
-        '--limit', nargs=1, dest='limit', required=True,
+        '--limit', nargs=1, dest='limit', required=False,
         type=int,
         help="""The limit of how many collections to move. Defaults to all."""
+        )
+    parser.add_argument(
+        '--add', action='store_true', required=False,
+        help="""Add a replica for collections on the source node."""
+        )
+    parser.add_argument(
+        '--dryrun', action='store_true', required=False,
+        help="""Simulate running."""
+        )
+    parser.add_argument(
+        '--json_file', nargs=1, dest='json_file', required=False,
+        help="""Read in collection list data from file (JSON format)."""
         )
     parser.add_argument(
         '--debug', action='store_true', required=False,
@@ -96,13 +229,13 @@ def parse_arguments():
         )
     return parser.parse_args()
 
-def configure_logging(log_level=logging.INFO):
+def configure_logging(logger_name, log_level=logging.INFO):
     """
     Configure logging for this script.
     :args log_level: logging level to set
     """
     global LOGGER
-    LOGGER = logging.getLogger('migrate_collections')
+    LOGGER = logging.getLogger(logger_name)
     LOGGER.setLevel(log_level)
     console_handler = logging.StreamHandler()
     console_handler.setLevel(log_level)
@@ -112,7 +245,7 @@ def configure_logging(log_level=logging.INFO):
         )
     console_handler.setFormatter(formatter)
     LOGGER.addHandler(console_handler)
-    LOGGER.debug('Starting init of %s', 'migrate_collections')
+    LOGGER.debug('Starting init of %s', logger_name)
 
 def main():
     """
@@ -127,19 +260,19 @@ def main():
 
     solr_cloud = None
     if args.debug:
-        configure_logging(log_level=logging.DEBUG)
-        solr_cloud = SolrCloudAdmin(
-            url=args.url[0],
-            log_level=logging.DEBUG,
-            max_retries=360,
-            retry_sleeptime=10
-            )
-    else:
-        configure_logging(log_level=logging.INFO)
+        configure_logging(logger_name='migrate_collections', log_level=logging.DEBUG)
         solr_cloud = SolrCloudAdmin(
             url=args.url[0],
             log_level=logging.INFO,
-            max_retries=360,
+            max_retries=3,
+            retry_sleeptime=10
+            )
+    else:
+        configure_logging(logger_name='migrate_collections', log_level=logging.INFO)
+        solr_cloud = SolrCloudAdmin(
+            url=args.url[0],
+            log_level=logging.INFO,
+            max_retries=3,
             retry_sleeptime=10
             )
 
@@ -148,80 +281,36 @@ def main():
     limit = 0
 
     if 'destination_node' in vars(args):
-        destination_node = args.destination_node[0]
-        LOGGER.debug('destination_node: %s', destination_node)
+        if args.destination_node:
+            destination_node = args.destination_node[0]
+            LOGGER.debug('destination_node: %s', destination_node)
     if 'limit' in vars(args):
-        limit = args.limit[0]
-        LOGGER.debug('limit: %s', limit)
+        if args.limit:
+            limit = args.limit[0]
+            LOGGER.debug('limit: %s', limit)
 
-    # Reset request ID
-    response = solr_cloud.get_request_status('-1')
-    if response['status'] != 0:
-        LOGGER.critical(
-            'Cleaning up stored states failed:\n%s',
-            solr_cloud.pretty_format(response)
+    json_file = None
+    if 'json_file' in vars(args):
+        if args.json_file:
+            json_file = args.json_file[0]
+
+    dryrun = False
+    if 'dryrun' in vars(args):
+        if args.dryrun:
+            dryrun = True
+
+    collection_list = get_collection_data(solr_cloud=solr_cloud, json_file=json_file)
+    if 'add' in vars(args):
+        return_value = add_replicas(
+            solr_cloud,
+            collection_list,
+            source_node,
+            destination_node,
+            limit,
+            dryrun
             )
-        return
-
-    # Set starting point for request IDs
-    request_id = 1000
-
-    count = 0
-    LOGGER.info('Moving: collection shard replica')
-    while limit == 0 or count < limit:
-        LOGGER.debug('count: %d', count)
-        LOGGER.debug('limit: %d', limit)
-        # Find collection to move
-        data = find_collection(
-            solr_cloud=solr_cloud,
-            source_node=source_node,
-            destination_node=destination_node
-            )
-
-        if data is None:
-            LOGGER.info('No more collections found to migrate')
-            break
-
-        # Check destination
-        response = check_destination(
-            solr_cloud=solr_cloud,
-            collection=data['collection'],
-            shard=data['shard'],
-            destination_node=destination_node
-            )
-        if response['status'] != 0:
-            LOGGER.critical(
-                'Problem with destination for replica.\n\
-                Response:\n\
-                %s\n\
-                Collection, shard, and replica information:\n\
-                %s',
-                solr_cloud.pretty_format(response),
-                solr_cloud.pretty_format(data)
-                )
-            break
-
-        # Move that collection
-        LOGGER.debug('Moving:\n%s', solr_cloud.pretty_format(data))
-        LOGGER.info('Moving: %s %s %s', data['collection'], data['shard'], data['replica'])
-        data = solr_cloud.move_replica(
-            collection=data['collection'],
-            shard=data['shard'],
-            replica=data['replica'],
-            destination_node=destination_node,
-            async=request_id
-            )
-        if data['status'] != 0:
-            LOGGER.critical(solr_cloud.pretty_format(data))
-            break
-        LOGGER.debug('move_replica response:\n%s', solr_cloud.pretty_format(data['response']))
-
-        # Repeat as limit allows
-        if limit > 0:
-            count += 1
-
-        # Increment request ID for next run
-        request_id += 1
+        LOGGER.info('add_replicas returned %s', return_value)
+    return
 
 if __name__ == '__main__':
     main()

--- a/migrate_collections.py
+++ b/migrate_collections.py
@@ -337,7 +337,7 @@ def parse_arguments():
         help="""Delete replicas from a collections found on the source node."""
         )
     parser.add_argument(
-        '--dry-run', action='store_true', required=False,
+        '--dry_run', action='store_true', required=False,
         help="""Simulate running."""
         )
     parser.add_argument(
@@ -419,7 +419,7 @@ def main():
     else:
         json_file = None
 
-    if 'dryrun' in vars(args) and args.dryrun:
+    if args.dry_run:
         dryrun = True
     else:
         dryrun = False

--- a/solrcloudadmin/solrcloudadmin.py
+++ b/solrcloudadmin/solrcloudadmin.py
@@ -149,6 +149,9 @@ class SolrCloudAdmin(object):
         """
         Return the state for the requested collection.
 
+        This includes information on shards, replicas, and other
+        important information.
+
         /zookeeper?detail=true&path=%2Fcollections%2Faws-stage-442%2Fstate.json
         """
         base_path = """/zookeeper?detail=true&path=%2Fcollections"""
@@ -298,17 +301,8 @@ class SolrCloudAdmin(object):
         base_path = """/admin/collections?action=REQUESTSTATUS&wt=json&requestid="""
 
         response = self._query('%s%s' % (base_path, str(requestid)))
-        self.logger.debug('\n%s', self.pretty_format(response))
-        if response['responseHeader']['status'] == 0:
-            return {
-                'status': 0,
-                'response': response
-                }
-        else:
-            return {
-                'status': 1,
-                'response': response
-                }
+        self.logger.debug('response = %s', response)
+        return response
 
     def move_shard(self, collection, shard, source_node, destination_node=None, async=None):
         """


### PR DESCRIPTION
The migrate_collections.py script can only add or delete collections it no longer uses the solrcloudadmin.py collection moving functions. See notes below.
#### Notes
- Rewrote migrate_collections.py
  - Add option to add replicas of collections on one host to another host
  - Delete option to delete replicas off a host if there is at least one other copy and more replicas then the collection's replication factor
- Wrote script to download collection data into JSON to be used locally by other scripts to save on time needed to download JSON from live cluster.
- Wrote script to gather replica information for all collections
  - Includes filter for results with greater or equal to replica count
  - Includes filter for node name
